### PR TITLE
NEW TK12201 - Génératuin CSV XPO expédition : tenir compte de l'entrepot ligne

### DIFF
--- a/class/xpoconnector.class.php
+++ b/class/xpoconnector.class.php
@@ -565,6 +565,7 @@ class XPOConnectorShipping extends XPOConnector
 
 			if(!empty($object->lines)) {
 				foreach($object->lines as $line) {
+				    if($line->entrepot_id != $conf->global->XPOCONNECTOR_XPO_WAREHOUSE) continue;
                     if($line->product_type != 0) continue;
                     $line->ref = $object->ref;
 					$line->fetch_optionals();


### PR DESCRIPTION
**NEW TK12201**
Si l'entrepot de la ligne d'expédition n'est pas celui configuré dans le module, alors on ne créé pas cette ligne dans le fichier csv. 