### PR TITLE
FIX tk12201 - lots des lignes d’expé non récupérés lorsqu’on clôture l’expédition

### DIFF
--- a/class/xpoconnector.class.php
+++ b/class/xpoconnector.class.php
@@ -526,6 +526,10 @@ class XPOConnectorShipping extends XPOConnector
 							'Message sur bon de livraison' => array('max_length' => 60, 'from_object' => 0)//Non géré
 	);
 
+	/**
+	 * @param Expedition $object
+	 * @return int
+	 */
 	public static function send($object) {
 		global $conf, $db, $langs;
 		if(!empty($conf->global->XPOCONNECTOR_ENABLE_SHIPPING)) {
@@ -582,6 +586,11 @@ class XPOConnectorShipping extends XPOConnector
 					}
 					if(empty($line->delivery_date)) $line->delivery_date = date('Ymd', $object->date_delivery);
 					//Génération du fichier CSV
+					if (empty($line->detail_batch)) {
+						// quand XPOConnectorShipping::send() est appelé lors de la clôture de l'expédition, les
+						// lots des lignes ne sont pas fetchés : il faut les fetcher explicitement
+						$line->detail_batch = ExpeditionLineBatch::fetchAll($db, $line->id, $line->fk_product);
+					}
 					if(!empty($line->detail_batch)) {
 						foreach($line->detail_batch as $detail_batch) {
 							$line->batch_number = $detail_batch->batch;


### PR DESCRIPTION
# FIX
[tk12201](https://support.atm-consulting.fr/view.php?id=12201#c40756) → Le fichier CSV ne contient qu'une ligne pour chaque ligne de l'expédition alors qu'il faut qu'il contienne autant de lignes qu'il y a de lots (donc si une ligne de l'expé se subdivise en 3 lots, il doit y avoir 3 lignes dans le CSV). 

Le bug ne se produit pas si on génère le CSV avec le bouton « Générer et transmettre le fichier à XPO », mais il se produit lorsque le CSV est généré automatiquement à la clôture de l’expédition.

## Analyse
C’est parce qu’à la clôture, les lots ne sont pas fetchés.